### PR TITLE
Updates for handling requestTimedOut signal, multiple requests in flight and other improvements.

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,10 @@ process it.
 
 BUILDING kQOAuth
 ===============================
-- Make sure that you have Qt 4.7 installed
+- Make sure that you have Qt 4.7 or greater installed
+
+For OS X and Linux:
+- run "qmake"
 - run "make" to build
 - Run "sudo make install" to install
 - To run unit tests you need to set platform specific variable to point 
@@ -19,6 +22,11 @@ BUILDING kQOAuth
   that it doesn't require kQOAuth to be installed in order to run unit tests.
  * for Linux:  export LD_LIBRARY_PATH=/path/to/kQOAuth/lib/dir
  * for OS X:  export DYLD_LIBRARY_PATH=/path/to/kQOAuth/lib/dir
+
+For Windows with the Visual Studio or Windows SDK Compiler
+- run "qmake CONFIG+=release"
+- run "nmake" to build
+- run "nmake install" to install
 
 
 COMPONENTS
@@ -52,7 +60,20 @@ Methods
     that the service sent back as a response to the request.
 
     If an error in the request was detected, this method will set the 
-    error code which can be retrieved by calling lastError();
+    error code and emit the requestReady(QByteArray) signal with 
+    an empty QByteArray. The error code can be retrieved by calling lastError().
+
+*   void executeAuthorizedRequest(KQOAuthRequest *request, int id)
+    - request: The KQOAuthRequest to process. 
+    - id: An id that is unique to the request.
+    
+    This method is useful for situations where the reponses from a server 
+    have different processing requirements.
+
+    The arguments and behavior of this method is similar to executeRequest() 
+    with the addition of an id that is mapped to the request. When the service 
+    has responded, the signal authorizedRequestReady(QByteArray, int) is emitted 
+    where the int is the mapped id.
 
 * void setHandleUserAuthorization(bool set)
     - set: A boolean value telling KQOAuthManager to process the user's 
@@ -127,6 +148,12 @@ Signals
     This signal is emitted after each request has been processed. It will
     return all the request response parameters in the QMultiMap, where
     the first parameter is the name and the second parameter is the value.
+
+* void authorizedRequestReady(QByteArray networkReply, int id);
+    - networkReply: The response as sent from the service the each request.
+    - id: The id that is mapped to the original request
+
+    This signal is emitted after each authorizedRequest has been processed.
 
 * void receivedToken(QString oauth_token, QString oauth_token_secret) 
     - oauth_oken: Token value
@@ -261,6 +288,9 @@ Methods
  * void clearRequest();
     Deletes all cached data from this request object.
 
+ * void setTimeout(int timeoutMilliseconds);
+    Sets the timeout for this request. If the timeout expires, the request will be aborted.
+
 
 SOURCE CODE
 ============================
@@ -288,6 +318,12 @@ The library and the source code is licensed under the GNU Lesser General Public
 License (LGPL). For more information, visit http://www.gnu.org/licenses/lgpl.html
 
 This library is written by Johan Paul (johan.paul@gmail.com)
+
+
+CONTRIBUTORS
+============================
+
+Keith Obenschain (obenschaink@gmail.com)
 
 
 ACKNOWLEDGEMENT

--- a/examples/twittercli/twittercli.cpp
+++ b/examples/twittercli/twittercli.cpp
@@ -17,7 +17,12 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with KQOAuth.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <QtCore>
+#if QT_VERSION < 0x050000
 #include <QCoreApplication>
+#else
+#include <QApplication>
+#endif
 #include <QStringList>
 #include <QtDebug>
 
@@ -155,9 +160,15 @@ void TwitterCLI::showHelp() {
 
 int main(int argc, char *argv[])
 {
+#if QT_VERSION < 0x050000
     QCoreApplication app(argc, argv);
     QCoreApplication::setOrganizationName("kQOAuth");
     QCoreApplication::setApplicationName("TwitterCLI");
+#else
+    QApplication app(argc, argv);
+    QApplication::setOrganizationName("kQOAuth");
+    QApplication::setApplicationName("TwitterCLI");
+#endif
 
     QStringList args = QCoreApplication::arguments();
 

--- a/examples/twittercli/twittercli.pro
+++ b/examples/twittercli/twittercli.pro
@@ -4,6 +4,9 @@ TEMPLATE = app
 # include(../../kqoauth.prf)
 
 QT += network
+windows {
+CONFIG += console
+}
 CONFIG += crypto
 CONFIG += kqoauth
 
@@ -17,7 +20,7 @@ else:unix {
   # being able to run make check from the root source directory
   LIBS += -L../../lib:lib
 } else:windows {
-  LIBS += -L../../lib -lkqoauthd0
+  LIBS += -L../../lib -lkqoauth0
 }
 
 #INCLUDEPATH += . ../../src

--- a/examples/twittercli/twittercli.pro
+++ b/examples/twittercli/twittercli.pro
@@ -10,6 +10,8 @@ CONFIG += console
 CONFIG += crypto
 CONFIG += kqoauth
 
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
 macx {
     CONFIG -= app_bundle
     QMAKE_POST_LINK += install_name_tool -change kqoauth.framework/Versions/0/kqoauth \

--- a/kqoauth.prf
+++ b/kqoauth.prf
@@ -29,6 +29,18 @@ mac: {
     }
 }
 
+windows: {
+    KQOAUTH_INCDIR = $$[QT_INSTALL_HEADERS]
+    KQOAUTH_LIBDIR = $$[QT_INSTALL_LIBS]
+    exists($$PWD/kqoauth.pro): {
+        KQOAUTH_INCDIR = $$PWD/include
+        KQOAUTH_LIBDIR = $$PWD/lib
+    }
+    INCLUDEPATH += $$KQOAUTH_INCDIR/QtKOAuth
+    LIBS += -L$$KQOAUTH_LIBDIR
+    LINKAGE = -lkqoauth0
+}
+
 # else, link normally
 isEmpty(LINKAGE) {
     exists($$PWD/kqoauth.pro): INCLUDEPATH += $$KQOAUTH_INCDIR
@@ -36,7 +48,6 @@ isEmpty(LINKAGE) {
     LIBS += -L$$KQOAUTH_LIBDIR
     LINKAGE = -lkqoauth
     CONFIG(debug, debug|release) {
-        windows:LINKAGE = -lkqoauth
         mac:LINKAGE = -lkqoauth_debug
     }
 }

--- a/src/kqoauthmanager.cpp
+++ b/src/kqoauthmanager.cpp
@@ -143,6 +143,9 @@ KQOAuthManager::KQOAuthManager(QObject *parent) :
     d_ptr(new KQOAuthManagerPrivate(this))
 {
 
+    qsrand(QTime::currentTime().msec());  // We need to seed the nonce random number with something.
+                                          // However, we cannot do this while generating the nonce since
+                                          // we might get the same seed. So initializing here should be fine.
 }
 
 KQOAuthManager::~KQOAuthManager()

--- a/src/kqoauthmanager.h
+++ b/src/kqoauthmanager.h
@@ -176,6 +176,7 @@ private Q_SLOTS:
     void onAuthorizedRequestReplyReceived( QNetworkReply *reply );
     void onVerificationReceived(QMultiMap<QString, QString> response);
     void slotError(QNetworkReply::NetworkError error);
+    void requestTimeout();
 
 private:
     KQOAuthManagerPrivate *d_ptr;

--- a/src/kqoauthmanager_p.h
+++ b/src/kqoauthmanager_p.h
@@ -66,6 +66,8 @@ public:
     bool managerUserSet;
     QMap<QNetworkReply*, int> requestIds;
 
+    QMap<KQOAuthRequest*, QNetworkReply*> requestMap;
+
     Q_DECLARE_PUBLIC(KQOAuthManager);
 };
 

--- a/src/kqoauthrequest.cpp
+++ b/src/kqoauthrequest.cpp
@@ -270,10 +270,12 @@ KQOAuthRequest::KQOAuthRequest(QObject *parent) :
     QObject(parent),
     d_ptr(new KQOAuthRequestPrivate)
 {
+    Q_D(KQOAuthRequest);
     d_ptr->debugOutput = false;  // No debug output by default.
     qsrand(QTime::currentTime().msec());  // We need to seed the nonce random number with something.
                                           // However, we cannot do this while generating the nonce since
                                           // we might get the same seed. So initializing here should be fine.
+    connect(&(d->timer), SIGNAL(timeout()), this, SIGNAL(requestTimedout()));
 }
 
 KQOAuthRequest::~KQOAuthRequest()
@@ -579,7 +581,6 @@ void KQOAuthRequest::requestTimerStart()
 {
     Q_D(KQOAuthRequest);
     if (d->timeout > 0) {
-        connect(&(d->timer), SIGNAL(timeout()), this, SIGNAL(requestTimedout()));
         d->timer.start(d->timeout);
     }
 }
@@ -587,8 +588,6 @@ void KQOAuthRequest::requestTimerStart()
 void KQOAuthRequest::requestTimerStop()
 {
     Q_D(KQOAuthRequest);
-    if (d->timeout > 0) {
-        disconnect(&(d->timer), SIGNAL(timeout()), this, SIGNAL(requestTimedout()));
+    if( d->timer.isActive() )
         d->timer.stop();
-    }
 }

--- a/src/kqoauthrequest.cpp
+++ b/src/kqoauthrequest.cpp
@@ -272,9 +272,6 @@ KQOAuthRequest::KQOAuthRequest(QObject *parent) :
 {
     Q_D(KQOAuthRequest);
     d_ptr->debugOutput = false;  // No debug output by default.
-    qsrand(QTime::currentTime().msec());  // We need to seed the nonce random number with something.
-                                          // However, we cannot do this while generating the nonce since
-                                          // we might get the same seed. So initializing here should be fine.
     connect(&(d->timer), SIGNAL(timeout()), this, SIGNAL(requestTimedout()));
 }
 

--- a/src/kqoauthrequest.h
+++ b/src/kqoauthrequest.h
@@ -86,8 +86,8 @@ public:
     void setHttpMethod(KQOAuthRequest::RequestHttpMethod = KQOAuthRequest::POST);
     KQOAuthRequest::RequestHttpMethod httpMethod() const;
 
-    // Sets the timeout for this request. If the timeout expires, signal "requestTimedout" will be
-    // emitted from the manager.
+    // Sets the timeout for this request. If the timeout expires, the signal "requestTimedout" will be
+    // emitted.  The KQOAuthManager will then call the abort() function from QNetworkReply associated with this request
     // 0 = If set to zero, timeout is disabled.
     // TODO: Do we need some request ID now?
     void setTimeout(int timeoutMilliseconds);

--- a/src/src.pro
+++ b/src/src.pro
@@ -91,6 +91,15 @@ else:unix {
         pkgconfig \
         features
 }
+else:windows {
+    INSTALL_PREFIX = $$[QT_INSTALL_PREFIX]
+    target.path = $${INSTALL_PREFIX}/lib
+    headers.path = $${INSTALL_PREFIX}/include/QtKOAuth
+    INSTALLS += \
+        target \
+        headers \
+        features
+}
 
 CONFIG(debug_and_release) {
     build_pass:CONFIG(debug, debug|release) {

--- a/tests/ft_kqoauth/ft_kqoauth.pro
+++ b/tests/ft_kqoauth/ft_kqoauth.pro
@@ -18,7 +18,7 @@ else:unix {
   LIBS += -L../../lib -lkqoauth
 }
 else:windows {
-  LIBS += -L../../lib -lkqoauthd0
+  LIBS += -L../../lib -lkqoauth0
 }
 
 INCLUDEPATH += . ../../src

--- a/tests/ut_kqoauth/ut_kqoauth.pro
+++ b/tests/ut_kqoauth/ut_kqoauth.pro
@@ -17,7 +17,7 @@ else:unix {
   LIBS += -L../../lib -lkqoauth
 }
 else:windows {
-  LIBS += -L../../lib -lkqoauthd0
+  LIBS += -L../../lib -lkqoauth0
 }
 
 INCLUDEPATH += . ../../src


### PR DESCRIPTION
Modifications for the following:
- Handle the requestTimedOut signal in KQOAuthManager
- Added QMap to map a request to the generated QNetworkReply
- Fix to significantly decrease the odds of the same nonce being generated for multiple requests launched within the resolution of the system clock.
- Updates so kQOAuth will install on Windows platforms
- Updated twitter client example so Qt5 variant will properly launch a web browser.
- Documentation updates
