### PR TITLE
Support opening auth page via a custom signal.

### DIFF
--- a/src/kqoauthmanager.cpp
+++ b/src/kqoauthmanager.cpp
@@ -38,6 +38,7 @@ KQOAuthManagerPrivate::KQOAuthManagerPrivate(KQOAuthManager *parent) :
     isVerified(false) ,
     isAuthorized(false) ,
     autoAuth(false),
+    handleAuthPageOpening(true),
     networkManager(new QNetworkAccessManager),
     managerUserSet(false)
 {
@@ -372,6 +373,12 @@ void KQOAuthManager::setHandleUserAuthorization(bool set) {
     d->autoAuth = set;
 }
 
+void KQOAuthManager::setHandleAuthorizationPageOpening(bool set) {
+    Q_D(KQOAuthManager);
+
+    d->handleAuthPageOpening = set;
+}
+
 bool KQOAuthManager::hasTemporaryToken() {
     Q_D(KQOAuthManager);
 
@@ -454,9 +461,13 @@ void KQOAuthManager::getUserAuthorization(QUrl authorizationEndpoint) {
     openWebPageUrl.setQuery(query);
 #endif
 
-    // Open the user's default browser to the resource authorization page provided
-    // by the service.
-    QDesktopServices::openUrl(openWebPageUrl);
+    if (d->handleAuthPageOpening) {
+        // Open the user's default browser to the resource authorization page provided
+        // by the service.
+        QDesktopServices::openUrl(openWebPageUrl);
+    } else {
+        emit authorizationPageRequested(openWebPageUrl);
+    }
 }
 
 void KQOAuthManager::getUserAccessTokens(QUrl accessTokenEndpoint) {

--- a/src/kqoauthmanager.h
+++ b/src/kqoauthmanager.h
@@ -71,6 +71,15 @@ public:
      */
     void setHandleUserAuthorization(bool set);
 
+    /** Indicates whether the KQOAuthManager should launch the browser with the user
+     * authorization page itself.
+     *
+     * If set to true (the default), the KQOAuthManager uses QDesktopServices::openUrl()
+     * for opening the browser. Otherwise it emits the authorizationPageRequested()
+     * signal which must then be handled by the calling code.
+     */
+    void setHandleAuthorizationPageOpening(bool set);
+
     /**
      * Returns true if the KQOAuthManager has retrieved the oauth_token value. Otherwise
      * return false.
@@ -148,6 +157,10 @@ Q_SIGNALS:
     void requestReady(QByteArray networkReply);
 
     void authorizedRequestReady(QByteArray networkReply, int id);
+
+    // This signal will be emitted when the authorization page should be opened if
+    // setHandleAuthorizationPageOpening() is set to false.
+    void authorizationPageRequested(QUrl pageUrl);
 
     // This signal will be emited when we have an request tokens available
     // (either temporary resource tokens, or authorization tokens).

--- a/src/kqoauthmanager_p.h
+++ b/src/kqoauthmanager_p.h
@@ -62,6 +62,7 @@ public:
     bool isVerified;
     bool isAuthorized;
     bool autoAuth;
+    bool handleAuthPageOpening;
     QNetworkAccessManager *networkManager;
     bool managerUserSet;
     QMap<QNetworkReply*, int> requestIds;


### PR DESCRIPTION
Some applications already have an integrated QWebView or something, so QDesktopServices::openUrl() can be a bit inconvenient. The proposed patch adds an option to emit a signal with the URL of the auth page instead of QDesktopServices::openUrl()'ing it. Of course, the default behavior isn't changed to keep compatibility.
