### PR TITLE
Allow for HEAD and DELETE requests

### DIFF
--- a/src/kqoauthrequest.cpp
+++ b/src/kqoauthrequest.cpp
@@ -378,6 +378,12 @@ void KQOAuthRequest::setHttpMethod(KQOAuthRequest::RequestHttpMethod httpMethod)
     case KQOAuthRequest::POST:
         requestHttpMethodString = "POST";
         break;
+    case KQOAuthRequest::HEAD:
+        requestHttpMethodString = "HEAD";
+        break;
+    case KQOAuthRequest::DELETE:
+        requestHttpMethodString = "DELETE";
+        break;
     default:
         qWarning() << "Invalid HTTP method set.";
         break;
@@ -438,7 +444,7 @@ QList<QByteArray> KQOAuthRequest::requestParameters() {
     if (!isValid() ) {
         qWarning() << "Request is not valid! I will still sign it, but it will probably not work.";
     }
-    
+
     d->signRequest();
 
     QPair<QString, QString> requestParam;

--- a/src/kqoauthrequest.h
+++ b/src/kqoauthrequest.h
@@ -50,7 +50,9 @@ public:
 
     enum RequestHttpMethod {
         GET = 0,
-        POST
+        POST,
+        HEAD,
+        DELETE
     };
 
     /**

--- a/tests/ft_kqoauth/ft_kqoauth.cpp
+++ b/tests/ft_kqoauth/ft_kqoauth.cpp
@@ -304,6 +304,128 @@ void Ft_KQOAuth::ft_AuthenticatedGetCall() {
 
 }
 
+void Ft_KQOAuth::ft_AuthenticatedHeadCall_data() {
+    QTest::addColumn<QUrl>("endpoint");
+    QTest::addColumn<QString>("consumerKey");
+    QTest::addColumn<QString>("consumerSecret");
+    QTest::addColumn<QString>("tokenSecret");
+    QTest::addColumn<QString>("token");
+    QTest::addColumn<QString>("data_key");
+    QTest::addColumn<QString>("data");
+
+
+    QTest::newRow("basicAccessToken")
+            << QUrl("http://term.ie/oauth/example/echo_api.php")
+            << QString("key")
+            << QString("secret")
+            << QString("accesssecret")
+            << QString("accesskey")
+            << QString("status")
+            << QString("This is a HEAD call");
+
+}
+
+void Ft_KQOAuth::ft_AuthenticatedHeadCall() {
+    QFETCH(QUrl, endpoint);
+    QFETCH(QString, consumerKey);
+    QFETCH(QString, consumerSecret);
+    QFETCH(QString, tokenSecret);
+    QFETCH(QString, token);
+    QFETCH(QString, data_key);
+    QFETCH(QString, data);
+
+
+    req->initRequest(KQOAuthRequest::AuthorizedRequest, endpoint);
+    req->setToken(token);
+    req->setTokenSecret(tokenSecret);
+    req->setConsumerKey(consumerKey);
+    req->setConsumerSecretKey(consumerSecret);
+    req->setHttpMethod(KQOAuthRequest::HEAD);
+
+    KQOAuthParameters params;
+    params.insert(data_key, data);
+    req->setAdditionalParameters(params);
+
+    QCOMPARE(req->isValid(), true);
+
+    MyEventLoop loop;
+
+    connect(manager, SIGNAL(requestReady(QByteArray)), &loop, SLOT(quit()));
+    connect(manager, SIGNAL(requestReady(QByteArray)), this, SLOT(onRequestReady(QByteArray)));
+    QTimer::singleShot( 10000, &loop, SLOT(quitWithTimeout()) );
+
+    manager->executeRequest(req);
+    loop.exec();
+
+    if ( loop.timeout() ) {
+        QWARN( "Request timeout" );
+    } else {
+        qDebug() << "Done!";
+    }
+
+}
+
+void Ft_KQOAuth::ft_AuthenticatedDeleteCall_data() {
+    QTest::addColumn<QUrl>("endpoint");
+    QTest::addColumn<QString>("consumerKey");
+    QTest::addColumn<QString>("consumerSecret");
+    QTest::addColumn<QString>("tokenSecret");
+    QTest::addColumn<QString>("token");
+    QTest::addColumn<QString>("data_key");
+    QTest::addColumn<QString>("data");
+
+
+    QTest::newRow("basicAccessToken")
+            << QUrl("http://term.ie/oauth/example/echo_api.php")
+            << QString("key")
+            << QString("secret")
+            << QString("accesssecret")
+            << QString("accesskey")
+            << QString("status")
+            << QString("This is a DELETE call");
+
+}
+
+void Ft_KQOAuth::ft_AuthenticatedDeleteCall() {
+    QFETCH(QUrl, endpoint);
+    QFETCH(QString, consumerKey);
+    QFETCH(QString, consumerSecret);
+    QFETCH(QString, tokenSecret);
+    QFETCH(QString, token);
+    QFETCH(QString, data_key);
+    QFETCH(QString, data);
+
+
+    req->initRequest(KQOAuthRequest::AuthorizedRequest, endpoint);
+    req->setToken(token);
+    req->setTokenSecret(tokenSecret);
+    req->setConsumerKey(consumerKey);
+    req->setConsumerSecretKey(consumerSecret);
+    req->setHttpMethod(KQOAuthRequest::DELETE);
+
+    KQOAuthParameters params;
+    params.insert(data_key, data);
+    req->setAdditionalParameters(params);
+
+    QCOMPARE(req->isValid(), true);
+
+    MyEventLoop loop;
+
+    connect(manager, SIGNAL(requestReady(QByteArray)), &loop, SLOT(quit()));
+    connect(manager, SIGNAL(requestReady(QByteArray)), this, SLOT(onRequestReady(QByteArray)));
+    QTimer::singleShot( 10000, &loop, SLOT(quitWithTimeout()) );
+
+    manager->executeRequest(req);
+    loop.exec();
+
+    if ( loop.timeout() ) {
+        QWARN( "Request timeout" );
+    } else {
+        qDebug() << "Done!";
+    }
+
+}
+
 void Ft_KQOAuth::ft_postRequestLotsOfData_data() {
     QTest::addColumn<QByteArray>("postData");
 

--- a/tests/ft_kqoauth/ft_kqoauth.h
+++ b/tests/ft_kqoauth/ft_kqoauth.h
@@ -60,6 +60,12 @@ private Q_SLOTS:
     void ft_AuthenticatedGetCall_data();
     void ft_AuthenticatedGetCall();
 
+    void ft_AuthenticatedHeadCall_data();
+    void ft_AuthenticatedHeadCall();
+
+    void ft_AuthenticatedDeleteCall_data();
+    void ft_AuthenticatedDeleteCall();
+
     void ft_postRequestLotsOfData_data();
     void ft_postRequestLotsOfData();
 


### PR DESCRIPTION
HEAD and DELETE have been supported by QNetworkAccessManager since before 4.7. As they make no large impact in the code, I see no harm in adding them.

It should be noted that term.ie times out on HEAD and DELETE requests, so the testing for them spits out a warning. However, I have checked their functionality with my server and they appeared to work fine.
