### PR TITLE
Add support for RSA-SHA1 signatures

### DIFF
--- a/src/kqoauthmanager.cpp
+++ b/src/kqoauthmanager.cpp
@@ -501,6 +501,7 @@ void KQOAuthManager::getUserAccessTokens(QUrl accessTokenEndpoint) {
     d->opaqueRequest->setVerifier(d->requestVerifier);
     d->opaqueRequest->setConsumerKey(d->consumerKey);
     d->opaqueRequest->setConsumerSecretKey(d->consumerKeySecret);
+    d->opaqueRequest->setSignatureMethod(d->signatureMethod);
 
     executeRequest(d->opaqueRequest);
 }
@@ -604,6 +605,7 @@ void KQOAuthManager::onRequestReplyReceived( QNetworkReply *reply ) {
             qDebug() << "Successfully got request tokens.";
             d->consumerKey = d->r->consumerKeyForManager();
             d->consumerKeySecret = d->r->consumerKeySecretForManager();
+            d->signatureMethod = d->r->requestSignatureMethodForManager();
             d->opaqueRequest->setSignatureMethod(KQOAuthRequest::HMAC_SHA1);
             d->opaqueRequest->setCallbackUrl(d->r->callbackUrlForManager());
 

--- a/src/kqoauthmanager_p.h
+++ b/src/kqoauthmanager_p.h
@@ -55,6 +55,7 @@ public:
     QString consumerKey;
     QString consumerKeySecret;
     QString requestVerifier;
+    KQOAuthRequest::RequestSignatureMethod signatureMethod;
 
     KQOAuthAuthReplyServer *callbackServer;
 

--- a/src/kqoauthrequest.cpp
+++ b/src/kqoauthrequest.cpp
@@ -105,11 +105,11 @@ QString KQOAuthRequestPrivate::oauthSignature()  {
     QByteArray baseString = this->requestBaseString();
 
     QString signature;
-    if (this->oauthSignatureMethod == "HMAC-SHA1") {
+    if (this->oauthSignatureMethod == "RSA-SHA1") {
+        signature = KQOAuthUtils::rsa_sha1(baseString, oauthConsumerSecretKey);
+    } else { // Default: Use HMAC-SHA1
         QString secret = QString(QUrl::toPercentEncoding(oauthConsumerSecretKey)) + "&" + QString(QUrl::toPercentEncoding(oauthTokenSecret));
         signature = KQOAuthUtils::hmac_sha1(baseString, secret);
-    } else if (this->oauthSignatureMethod == "RSA-SHA1") {
-        signature = KQOAuthUtils::rsa_sha1(baseString, oauthConsumerSecretKey);
     }
 
     if (debugOutput) {

--- a/src/kqoauthrequest.h
+++ b/src/kqoauthrequest.h
@@ -132,6 +132,7 @@ private:
     // work with the opaque request.
     QString consumerKeyForManager() const;
     QString consumerKeySecretForManager() const;
+    KQOAuthRequest::RequestSignatureMethod requestSignatureMethodForManager() const;
     QUrl callbackUrlForManager() const;
 
     // This method is for timeout handling by the KQOAuthManager.

--- a/src/kqoauthrequest_p.h
+++ b/src/kqoauthrequest_p.h
@@ -57,6 +57,7 @@ public:
     QString oauthToken;
     QString oauthTokenSecret;
     QString oauthSignatureMethod;
+    KQOAuthRequest::RequestSignatureMethod requestSignatureMethod;
     QUrl oauthCallbackUrl;
     QString oauthVersion;
     QString oauthVerifier;

--- a/src/kqoauthutils.cpp
+++ b/src/kqoauthutils.cpp
@@ -24,6 +24,12 @@
 #include <QtDebug>
 #include "kqoauthutils.h"
 
+#include <openssl/pem.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/evp.h>
+
+
 QString KQOAuthUtils::hmac_sha1(const QString &message, const QString &key)
 {
     QByteArray keyBytes = key.toLatin1();
@@ -76,4 +82,61 @@ QString KQOAuthUtils::hmac_sha1(const QString &message, const QString &key)
     /* http://tools.ietf.org/html/rfc2104 - (7) */
     sha1 = QCryptographicHash::hash(workArray, QCryptographicHash::Sha1);
     return QString(sha1.toBase64());
+}
+
+QString KQOAuthUtils::rsa_sha1(const QString &message, const QString &key)
+{
+    SSL_load_error_strings();
+    OpenSSL_add_all_algorithms();
+    OpenSSL_add_all_ciphers();
+    OpenSSL_add_all_digests();
+
+    EVP_PKEY *evpKey = 0;
+    evpKey = EVP_PKEY_new();
+
+    RSA *rsa = 0;
+    rsa = getRsaFromKey(key);
+
+    EVP_PKEY_set1_RSA(evpKey, rsa);
+
+    EVP_MD_CTX* ctx = 0;
+    ctx = EVP_MD_CTX_create();
+    EVP_SignInit_ex(ctx, EVP_sha1(), 0);
+    QByteArray latinMessage = message.toLatin1();
+    EVP_SignUpdate(ctx, latinMessage.data(), strlen(latinMessage.data()));
+
+    const int MAX_LEN = 1024;
+    unsigned char *sig = new unsigned char[MAX_LEN];
+    unsigned int sigLen;
+
+    EVP_SignFinal(ctx, sig, &sigLen, evpKey);
+    sig[sigLen] = '\0';
+
+    EVP_MD_CTX_destroy(ctx);
+    RSA_free(rsa);
+    EVP_PKEY_free(evpKey);
+    ERR_free_strings();
+
+    QByteArray ret((char *)sig, sigLen);
+
+    return QString(ret.toBase64());
+}
+
+RSA* KQOAuthUtils::getRsaFromKey(const QString &key)
+{
+    BIO *bufio;
+    QByteArray data = key.toLocal8Bit();
+    char *pem_key_buffer = data.data();
+    int pem_key_buffer_len = strlen(pem_key_buffer);
+
+    bufio = BIO_new_mem_buf((void*)pem_key_buffer, pem_key_buffer_len);
+    RSA *rsa = 0;
+    rsa = RSA_new();
+    rsa = PEM_read_bio_RSAPrivateKey(bufio, 0, 0, NULL);
+    if (rsa == 0) {
+        printf("Can not parse RSA data. Errors:\n");
+        ERR_print_errors_fp(stderr);
+        exit(1);
+    }
+    return rsa;
 }

--- a/src/kqoauthutils.h
+++ b/src/kqoauthutils.h
@@ -22,12 +22,18 @@
 
 #include "kqoauthglobals.h"
 
+#include <openssl/rsa.h>
+
 class QString;
 class KQOAUTH_EXPORT KQOAuthUtils
 {
 public:
 
     static QString hmac_sha1(const QString &message, const QString &key);
+    static QString rsa_sha1(const QString &message, const QString &key);
+
+private:
+    static RSA* getRsaFromKey(const QString &key);
 };
 
 #endif // KQOAUTHUTILS_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -15,6 +15,8 @@ OBJECTS_DIR = tmp
 MOC_DIR = tmp
 INC_DIR = ../include
 
+LIBS += -lssl -lcrypto
+
 INCLUDEPATH += .
 
 PUBLIC_HEADERS += kqoauthmanager.h \


### PR DESCRIPTION
Although the library did suggest (in the code) supporting RSA-SHA1 signatures, it did not.
Because I needed it, I have added code to do so.

What I have done:
- Added `signatureMethod` to the OAuthManager, so we can send it with opaque requests
- Added some code to the OAuthRequest class to call the RSA generate function
- Added `requestSignatureMethodForManager()` to the OuathRequest, so it can be used by the manager
- Updated the .pro to link against the ssl and crypto libraries (note I tested it on Mac OS X. It can be the case library paths are not correct on Linux or Windows. Could anyone check?)
- Added a RSA-SHA1 generate function to `KQOAuthUtils`. Note that my knowledge of OpenSSL is not that advanced, so I was unable to directly read in a DER format.

To use it, add:

``` C++
oauthRequest->setSignatureMethod(KQOAuthRequest::RSA_SHA1);
```

To all requests. The consumer secret key should be the contents of your RSA private file, as generated by openssl.
I used a define for this:

``` C++
#define SECRET_KEY "-----BEGIN RSA PRIVATE KEY-----\n" \
"MIIC…….ekH\n" \
"eAo….MoG\n" \
"….." \
"0Gx….aPaJA==\n" \
"-----END RSA PRIVATE KEY-----\n"
```

I hope this will help other people too!
