### PR TITLE
Update pcfile.sh to be compatible with Qt5

### DIFF
--- a/src/pcfile.sh
+++ b/src/pcfile.sh
@@ -10,6 +10,6 @@ includedir=\${prefix}/include/QtKOAuth
 Name: KQOAuth
 Description: Qt OAuth support library
 Version: $2
-Requires: QtCore QtNetwork
+Requires: Qt5Core Qt5Network
 Libs: -L\${libdir} -lkqoauth
 Cflags: -I\${includedir}" > kqoauth.pc


### PR DESCRIPTION
The previous version of the file assumed a Qt4 build and used the Qt4 library names. Qt4 is dead for about 5 years now, so I think it's safe to unconditionally port to Qt5.